### PR TITLE
Correct error in Chapter 6

### DIFF
--- a/06-regularization.Rmd
+++ b/06-regularization.Rmd
@@ -247,10 +247,10 @@ lasso_final <- finalize_workflow(lasso_workflow, best_penalty)
 lasso_final_fit <- fit(lasso_final, data = Hitters_train)
 ```
 
-And we are done, by calculating the `rsq` value for the lasso model can we see that for this data it doesn't make much difference which kind of regularization we use as they have similar performance.
+And we are done, by calculating the `rsq` value for the lasso model can we see that for this data ridge regression outperform lasso regression.
 
 ```{r}
-augment(ridge_final_fit, new_data = Hitters_test) %>%
+augment(lasso_final_fit, new_data = Hitters_test) %>%
   rsq(truth = Salary, estimate = .pred)
 ```
 


### PR DESCRIPTION
In "Chapter 6: Linear Model Selection and Regularization" line 250-255, when evaluating the R-square of lasso regression using `augment`, the model plugged in was `ridge_final_fit` instead of `lasso_final_fit`, resulting in identical R-square value. After correcting the model plugged in to `lasso_final_fit`, the resulting R-square is 0.491, lower than ridge regression model.