### PR TITLE
Fix broken survival analysis link

### DIFF
--- a/11-survival-analysis.Rmd
+++ b/11-survival-analysis.Rmd
@@ -4,4 +4,4 @@
 set.seed(1234)
 ```
 
-[https://github.com/tidymodels/planning/tree/master/survival-analysis](survival analysis) is being worked on in tidymodels but is not yet ready to be included in this book yet.
+[Survival analysis](https://github.com/tidymodels/planning/tree/master/survival-analysis) is being worked on in tidymodels but is not yet ready to be included in this book yet.


### PR DESCRIPTION
I'm not sure if you still want to go to that discussion or go to {censored} or maybe just wait to update it when {censored} is published, but the link is currently broken.