### PR TITLE
`estimate` is no longer used by roc_curve

### DIFF
--- a/09-support-vector-machines.qmd
+++ b/09-support-vector-machines.qmd
@@ -215,11 +215,11 @@ augment(svm_rbf_fit, new_data = sim_data2_test) %>%
 
 ## ROC Curves
 
-ROC curves can easily be created using the `roc_curve()` function from the yardstick package. We use this function much the same way as we have done using the `accuracy()` function, but the main difference is that we pass the predicted class probability to `estimate` instead of passing the predicted class.
+ROC curves can easily be created using the `roc_curve()` function from the yardstick package. We use this function much the same way as we have done using the `accuracy()` function, but the main difference is that we pass the predicted class probability instead of passing the predicted class.
 
 ```{r}
 augment(svm_rbf_fit, new_data = sim_data2_test) %>%
-  roc_curve(truth = y, estimate = .pred_1)
+  roc_curve(truth = y, .pred_1)
 ```
 
 This produces the different values of `specificity` and `sensitivity` for each threshold. We can get a quick visualization by passing the results of `roc_curve()` into `autoplot()`
@@ -232,7 +232,7 @@ This produces the different values of `specificity` and `sensitivity` for each t
 #|   along the diagonal. The line quite closely follows
 #|   the upper left side.
 augment(svm_rbf_fit, new_data = sim_data2_test) %>%
-  roc_curve(truth = y, estimate = .pred_1) %>%
+  roc_curve(truth = y, .pred_1) %>%
   autoplot()
 ```
 
@@ -240,7 +240,7 @@ A common metric is t calculate the area under this curve. This can be done using
 
 ```{r}
 augment(svm_rbf_fit, new_data = sim_data2_test) %>%
-  roc_auc(truth = y, estimate = .pred_1)
+  roc_auc(truth = y, .pred_1)
 ```
 
 ## Application to Gene Expression Data


### PR DESCRIPTION
passing estimate throws a `! Can't rename variables in this context.` error in yardstick v1.2.0